### PR TITLE
Allow to output to a file

### DIFF
--- a/tasks/git-describe.js
+++ b/tasks/git-describe.js
@@ -1,8 +1,7 @@
 module.exports = function( grunt ) {
-	grunt.registerTask("describe", "Describes current git commit", function (propArg) {
-		var done = this.async();
-		var dirtyMark = grunt.config.process("describe.dirtyMark") || "-dirty";
-		var prop = propArg || grunt.config.process("describe.prop") || "meta.version";
+	grunt.registerTask("describe", "Describes current git commit", function () {
+    var done = this.async();
+		var dirtyMark = grunt.config("describe.dirtyMark") || "-dirty";
 		var util = "0.4" > grunt.version ? grunt.utils : grunt.util;
 
 		grunt.log.write("Describe current commit: ");
@@ -16,9 +15,12 @@ module.exports = function( grunt ) {
 				return done(false);
 			}
 
-			grunt.config(prop, result);
+			grunt.log.writeln(result.toString().green);
 
-			grunt.log.writeln((prop + " = " + result).green);
+      var outFile;
+      if (outFile = grunt.config('describe.out')) {
+        grunt.file.write(outFile, result);
+      }
 
 			done(result);
 		});


### PR DESCRIPTION
Hi,
I submit this pull request, which is 2-fold:
- Allows the task to produce an actual file which contents is the current revision, with the `out` property
- Remove the ability to augment the grunt config with the results

If you want to augment the grunt config with the results of `grunt-git-describe` for other tasks, you can still use templating once `grunt-git-describe` has been run, like

```
<%= meta.version>
```
