### PR TITLE
Fix non-functional describe config lookup

### DIFF
--- a/tasks/git-describe.js
+++ b/tasks/git-describe.js
@@ -1,9 +1,11 @@
 module.exports = function( grunt ) {
 	grunt.registerTask("describe", "Describes current git commit", function (propArg) {
 		var done = this.async();
-		var dirtyMark = grunt.config.process("describe.dirtyMark") || "-dirty";
-		var prop = propArg || grunt.config.process("describe.prop") || "meta.version";
+		var dirtyMark = grunt.config.get("describe.dirtyMark");
+		var prop = propArg || grunt.config.get("describe.prop") || "meta.version";
 		var util = "0.4" > grunt.version ? grunt.utils : grunt.util;
+
+		dirtyMark = dirtyMark === null ? "-dirty" : dirtyMark;
 
 		grunt.log.write("Describe current commit: ");
 


### PR DESCRIPTION
The current version of `grunt.config.process` does not do a config lookup; it
simply processes a value, so `describe.dirtyMark` was always
"describe.dirtyMark".

Instead, call `grunt.config.get`.

Also allow falsy values for `dirtyMark` (the empty string, e.g.).
