### PR TITLE
Error handling option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Default value: `'-dirty'`
 
 A string value that is used as the for the `dirty=` option passed to `git`
 
+#### options.failOnError
+Type: `boolean`  
+Default value: `true`
+
+A boolean that allows Grunt to keep going if there's an error in this task. This is useful if your build isn't guaranteed to always be run from within a Git repo.
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 

--- a/tasks/git-describe.js
+++ b/tasks/git-describe.js
@@ -11,6 +11,7 @@
 module.exports = function (grunt) {
 	var CWD = "cwd";
 	var PROP = "prop";
+	var FAIL_ON_ERROR = "failOnError";
 	var DIRTY_MARK = "dirtyMark";
 
 	grunt.registerMultiTask("git-describe", "Describes current git commit", function (prop, cwd) {
@@ -21,6 +22,7 @@ module.exports = function (grunt) {
 		var options = {};
 		options[CWD] = ".";
 		options[DIRTY_MARK] = "-dirty";
+		options[FAIL_ON_ERROR] = true;
 
 		// Load cli options (with defaults)
 		options = this.options(options);
@@ -43,11 +45,17 @@ module.exports = function (grunt) {
 		}, function (err, result) {
 			// If an error occurred...
 			if (err) {
-				// Done with false
-				done(false);
-
-				// Fail with error
-				grunt.fail.warn(err);
+				// ... and we consider this case fatal
+				if ( options[FAIL_ON_ERROR] ) {
+					// Log the problem and tell grunt to stop
+					done(false);
+					grunt.fail.warn(err);
+				} else {
+                    // Log the problem and let grunt continue
+					grunt.log.error(err,result);
+					done();
+				}
+				return;
 			}
 
 			// Convert result to string
@@ -60,9 +68,9 @@ module.exports = function (grunt) {
 			if (options[PROP]) {
 				grunt.config(options[PROP], result);
 			}
-
+            
 			// Done with result
-			done(result);
+			done();
 		});
 	});
 };


### PR DESCRIPTION
Hi, thanks for sharing this, very handy.

We currently have a slightly curious setup with devs using either Subversion or Git SVN to share code internally. I've got `grunt-svninfo` working for the SVN people, and I'd like something in place for those using Git... but `git-describe` is would currently break the build for those not using Git.

So... here's a pull request that leaves the default behaviour unchanged, but adds a failOnError option, that if you explicitly set to `false` will allow the build to continue on an error (such as git not being found). Hopefully I've stuck closely enough to the existing style. I've also documented the new option in the README.

I haven't added tests because I didn't want to push my test-framework choices onto you, but happy to add tests for this later if you decide on test tools
