### PR TITLE
Adds support to "--match <pattern>”

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Default value: `true`
 
 A boolean that allows Grunt to keep going if there's an error in this task. This is useful if your build isn't guaranteed to always be run from within a Git repo.
 
+#### options.match
+Type: `String`
+Default value: `*`
+
+A string pattern used to find the required tag. See [git describe --match <pattern>](https://git-scm.com/docs/git-describe#git-describe---matchltpatterngt) documentation.
+
 ### Saving Output
 If you would like to save or otherwise use the retun value, use `grunt.event.emit`. Here is an example:
 ```js

--- a/tasks/git-describe.js
+++ b/tasks/git-describe.js
@@ -20,12 +20,14 @@ module.exports = function (grunt) {
 	var COMMITISH = "commitish";
 	var TEMPLATE = "template";
 	var FAIL_ON_ERROR = "failOnError";
+	var MATCH = "match";
 
 	// Initial OPTIONS
 	var OPTIONS = {};
 	OPTIONS[CWD] = ".";
 	OPTIONS[TEMPLATE] = "{%=tag%}-{%=since%}-{%=object%}{%=dirty%}";
 	OPTIONS[FAIL_ON_ERROR] = true;
+	OPTIONS[MATCH] = "*";
 
 	// Add GIT_DESCRIBE delimiters
 	grunt.template.addDelimiters(GIT_DESCRIBE, "{%", "%}");
@@ -38,7 +40,7 @@ module.exports = function (grunt) {
 		var done = me.async();
 
 		// Get options and process
-		var options = _process.call(_options.call(me, _.defaults(_args.call(me, COMMITISH, CWD, TEMPLATE), me.options(OPTIONS)), COMMITISH, CWD, TEMPLATE, FAIL_ON_ERROR), {
+		var options = _process.call(_options.call(me, _.defaults(_args.call(me, COMMITISH, CWD, TEMPLATE), me.options(OPTIONS)), COMMITISH, CWD, TEMPLATE, FAIL_ON_ERROR, MATCH), {
 			"delimiters" : GIT_DESCRIBE
 		}, COMMITISH, CWD, FAIL_ON_ERROR);
 
@@ -48,7 +50,7 @@ module.exports = function (grunt) {
 		// Spawn git
 		_spawn({
 			"cmd" : "git",
-			"args" : [ "describe", "--tags", "--always", "--long", options[COMMITISH] || "--dirty" ],
+			"args" : [ "describe", "--tags", "--always", "--long", "--match="+options[MATCH], options[COMMITISH] || "--dirty" ],
 			"opts" : {
 				"cwd" : options[CWD]
 			}


### PR DESCRIPTION
This PR adds support to the --match pattern allowing output different tags.

Ex tags:
api/v1.2.3
v1.2.3

match: "v*" will match "v1.2.3"
match: "api/*" will match "api/v1.2.3"