### PR TITLE
Update `grunt` in the `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt": "~0.4.1"
   },
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": ">=0.4.1"
   },
   "keywords": [
     "gruntplugin"


### PR DESCRIPTION
https://github.com/gruntjs/grunt/blob/master/CHANGELOG
 - if you have a Grunt plugin that includes `grunt` in the `peerDependencies`, we recommend tagging with `"grunt": "">= 0.4.0"` and publishing a new version on npm.